### PR TITLE
Correct a spec's call to a function

### DIFF
--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -110,7 +110,7 @@ describe 'Movie' do
       end
 
       it 'can use a where clause and be sorted' do
-        expect(can_find_using_where_clause.map{|m| m.title}).to eq(["Movie_4", "Movie_3"])
+        expect(can_find_using_where_clause_and_be_sorted.map{|m| m.title}).to eq(["Movie_4", "Movie_3"])
       end
     end
 


### PR DESCRIPTION
`can_find_using_where_clause` was missing `_and_be_sorted`.