### PR TITLE
Make method name consistent with specs.

### DIFF
--- a/app/movies_controller.rb
+++ b/app/movies_controller.rb
@@ -44,7 +44,7 @@ def can_find_the_first_item_from_the_database_using_id
   __
 end
 
-def can_find_by_different_attributes
+def can_find_by_multiple_attributes
   # title == "Title"
   # release_date == 2000, 
   # director == "Me"


### PR DESCRIPTION
This method is defined as `can_find_by_different_attributes` but referenced as `can_find_by_multiple_attributes` in the specs.