### PR TITLE
modified 'can be created in a block' spec 

### DIFF
--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -70,7 +70,9 @@ describe 'Movie' do
       end
 
       it 'can be created in a block' do
-        movie = can_be_created_in_a_block
+        title = "Home Alone"
+        year  = 1990
+        movie = can_be_created_in_a_block(title, year)
 
         expect(Movie.last).to eq(movie)
         expect(Movie.last.title).to eq("Home Alone")


### PR DESCRIPTION
* related to issue #34 (@leiaj)  ; I believe this would negate the need to hardcode in the values (though perhaps that has its advantages?)

* spec was not specifying the movie attribute values that it was subsequently searching for after calling can_be_created_in_a_block

* modified this call in the spec to send in those values

*   this requires student to add params to the method definition; i did not modify the "blank" method definition provided initially (to indicate parameters were required in the argument); not sure if you wanted to add those or not