### PR TITLE
can_be_created_in_a_block: Add ability to take args

### DIFF
--- a/app/movies_controller.rb
+++ b/app/movies_controller.rb
@@ -22,7 +22,7 @@ def can_be_created_with_a_hash_of_attributes
   movie = __
 end
 
-def can_be_created_in_a_block
+def can_be_created_in_a_block(args = {})
   Movie.create do |m|
     __
   end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -69,14 +69,22 @@ describe 'Movie' do
         expect(Movie.find_by(attributes)).to eq(movie)
       end
 
-      it 'can be created in a block' do
+      it 'can be created in a block when no args are passed' do
         movie = can_be_created_in_a_block
 
-        expect(Movie.last).to eq(movie)
-        expect(Movie.last.title).to eq("Home Alone")
-        expect(Movie.last.release_date).to eq(1990)
+        expect(movie.title).to eq("Home Alone")
+        expect(movie.release_date).to eq(1990)
       end
-    end
+
+      it 'can be created in a block' do
+        movie = can_be_created_in_a_block
+        args = { title: "The Room", release_date: 2003 }
+        movie = can_be_created_in_a_block(args)
+
+        expect(movie.title).to eq("The Room")
+        expect(movie.release_date).to eq(2003)
+      end
+   end
 
     context 'reading' do
       before do


### PR DESCRIPTION
Per #34 and #35, we're effectively hard-coding the
solution and it requires students to _narrowly_
reverse engineer an implementation that seems odd
in order to make a test pass.